### PR TITLE
Refatoração do import_company_excel

### DIFF
--- a/app/services/company_excel_parser.rb
+++ b/app/services/company_excel_parser.rb
@@ -1,0 +1,25 @@
+class CompanyExcelParser
+  attr_accessor :path, :file
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(path)
+    @path = path
+  end
+
+  def call
+    @file = Roo::Spreadsheet.open(@path.to_s, extension: :xlsx)
+    rows = @file.sheet(@file.sheets.first).to_a
+    rows.shift
+
+    rows.map do |row|
+      {
+        name: row[0],
+        code: row[1],
+        token: row[2]
+      }
+    end
+  end
+end

--- a/app/services/import_company_excel.rb
+++ b/app/services/import_company_excel.rb
@@ -1,7 +1,7 @@
 require 'roo'
 
 class ImportCompanyExcel
-  attr_accessor :file, :path, :capture_errors
+  attr_accessor :path, :capture_errors
 
   def initialize(path)
     @path = path
@@ -9,7 +9,6 @@ class ImportCompanyExcel
   end
 
   def execute
-    prepare_objects
     create_records
   end
 
@@ -19,24 +18,14 @@ class ImportCompanyExcel
 
   private
 
-  def prepare_objects
-    @file = Roo::Spreadsheet.open(@path.to_s, extension: :xlsx)
-    rows = @file.sheet(@file.sheets.first).to_a
-    rows.shift
-
-    @parsed_data = rows.map do |row|
-      {
-        name: row[0],
-        code: row[1],
-        token: row[2]
-      }
-    end
+  def parsed_data
+    CompanyExcelParser.call(path)
   end
 
   def create_records
     Company.transaction do
       begin
-        Company.create!(@parsed_data)
+        Company.create!(parsed_data)
       rescue ActiveRecord::RecordInvalid => e
         @capture_errors << e
         raise ActiveRecord::Rollback


### PR DESCRIPTION
Apenas fiz uma pequena refatoração para separar a responsabilidade de realizar o parser do excel.
Antes a classe ImportCompanyExcel realizava o parser e a importação. Apenas criei uma nova classe CompanyExcelParser para lidar com a lógica da extração dos dados. Sei que foi só um exemplo que você deu no github, mas quis dar uma contribuição também.